### PR TITLE
Flicker demonstration

### DIFF
--- a/UISyncedMap/ViewController.swift
+++ b/UISyncedMap/ViewController.swift
@@ -30,6 +30,8 @@ class ViewController: UIViewController, MGLMapViewDelegate {
         map.autoresizingMask = .FlexibleWidth | .FlexibleHeight
         map.setCenterCoordinate(points[0], zoomLevel: 16, animated: false)
         view.addSubview(map)
+        
+        map.setVisibleCoordinates(&self.points, count: UInt(self.points.count), edgePadding: UIEdgeInsetsZero, animated: false)
 
         path = MGLPolyline(coordinates: &self.points, count: UInt(self.points.count))
         self.map.addAnnotation(path)
@@ -62,7 +64,7 @@ class ViewController: UIViewController, MGLMapViewDelegate {
             map.addAnnotation(MGLPolyline(coordinates: &segmentPoints, count: UInt(segmentPoints.count)))
         }
 
-        map.setCenterCoordinate(points[start], zoomLevel: map.zoomLevel, animated: false)
+        //map.setCenterCoordinate(points[start], zoomLevel: map.zoomLevel, animated: false)
     }
 
     func mapView(mapView: MGLMapView, lineWidthForPolylineAnnotation annotation: MGLPolyline) -> CGFloat {


### PR DESCRIPTION
The sample project seems to not flicker too much when zoomed in a lot, but when you zoom out to fill the entire user path it demonstrates the flicker easily. Even though only one annotation is being added / removed, the main user route annotation flickers and it has to be redrawn.
